### PR TITLE
Fixed CL_INVALID_GL_SHAREGROUP_REFERENCE_KHR

### DIFF
--- a/src/gpu_wrappers/cl_context.cpp
+++ b/src/gpu_wrappers/cl_context.cpp
@@ -34,6 +34,14 @@
 #define NOMINMAX
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
+
+ // Use discrete GPU by default.
+extern "C" {
+    __declspec(dllexport) DWORD NvOptimusEnablement = 0x00000001;
+
+    __declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
+}
+
 #endif
 
 CLContext::CLContext(const cl::Platform& platform)


### PR DESCRIPTION
This error **Failed to create OpenCL context (CL_INVALID_GL_SHAREGROUP_REFERENCE_KHR)** is occurring on my laptop. It is happening because OpenGL is selecting the integrated GPU as the first device. Removing the discrete GPU from the OpenCL device list will solve the issue, but rendering on the integrated GPU is too slow.